### PR TITLE
test(all): add all integration tests (ITs)

### DIFF
--- a/tests/api_test/slack_api_connection_integration_test.py
+++ b/tests/api_test/slack_api_connection_integration_test.py
@@ -1,0 +1,83 @@
+from src import slack_api_connection, utils, cadocs
+from cadocs import Cadocs
+from utils import CadocsIntents
+import pytest
+import requests
+from unittest.mock import Mock, patch
+
+
+class TestSlackAPIConnectionIT:
+
+    def mock_handle_request(self):
+        return "test_value"
+
+    def test_handle_request(self, mocker):
+
+        data_test = {"channel": {"id": 1},
+                     "user": {"id": "id_test"},
+                     "actions": [{"action_id": "action-yes"}],
+                     "message": {"ts": 10}}
+
+        event = {
+            "client_msg_id": "msg_test",
+            "user": "user_test",
+            "text": "can you detect community smells in this repo https://github.com/tensorflow/ranking?",
+            "bot_id": None,
+            "channel": "channel_test"
+        }
+        payload = {"event": event}
+
+        # Mock the start method of Thread class
+        mocker.patch.object(slack_api_connection.threading.Thread,
+                            'start', return_value=self.mock_handle_request)
+
+        # Mock the auth_test function of slack_web_client
+        mocker.patch.object(slack_api_connection.WebClient,
+                            "auth_test", return_value=True)
+        # Mock the users_info function of slack_web_client
+        mocker.patch.object(slack_api_connection.WebClient, "users_info",
+                            return_value={"user": {"id": "id_test"}})
+        # Mock the chat_postMessage function of slack_web_client
+        mocker.patch.object(slack_api_connection.WebClient,
+                            "chat_postMessage", return_value=data_test.get("message"))
+
+        mocker.patch('slack_api_connection.os.environ.get', side_effect=[
+            "CADOCSNLU_URL_PREDICT", "0.77", "0.55", "0.77", "CSDETECTOR_URL_GETSMELLS"])
+
+        response_intent_manager = {
+            "intent": {
+                "intent": {
+                    "name": "get_smells",
+                    "confidence": 0.8
+                }
+            },
+            "entities": {"url": "https://github.com/tensorflow/ranking"}
+        }
+
+        response = {
+            "files": [],
+            "result": [
+                "test",
+                "BCE"
+            ]
+        }
+
+        # Mock the Response objects with a mock dict
+        mock_response_intent_manager = Mock(spec=requests.Response)
+        mock_response_intent_manager.json.return_value = response_intent_manager
+        mock_response_tools = Mock(spec=requests.Response)
+        mock_response_tools.json.return_value = response
+
+        # Mock requests.get method
+        mocker.patch("slack_api_connection.requests.get",
+                     side_effect=[mock_response_intent_manager, mock_response_tools])
+
+        # Mock os.environ.get method
+        mocker.patch('tools.os.environ.get', side_effect=[
+            "CADOCSNLU_URL_PREDICT", "0.77", "0.55", "0.77"])
+
+        expected_response = {"message": "true"}
+        response = slack_api_connection.handle_request(payload)
+
+        # Assertion
+        assert expected_response == response

--- a/tests/chatbot_test/Cadocs_integration_test.py
+++ b/tests/chatbot_test/Cadocs_integration_test.py
@@ -1,0 +1,252 @@
+from src import intent_manager, intent_resolver, utils, cadocs
+from intent_manager import IntentManager
+from intent_resolver import IntentResolver
+from utils import CadocsIntents
+from cadocs import Cadocs
+from tests.service_test.cadocs_messages_unit_test import TestCadocsMessagesUT
+import requests
+from unittest.mock import Mock, patch
+import pytest
+import json
+
+
+class TestCadocsIT:
+
+    @pytest.fixture
+    def cadocs_instance(self):
+        cadocs = Cadocs()
+        yield cadocs
+
+    def test_new_message_get_smells_valid_link(self, cadocs_instance, mocker):
+        exec_data = {
+            "text": "can you get community smells for this repo https://github.com/tensorflow/ranking",
+            "approved": True,
+            "executed": False
+        }
+        user = {
+            "id": "1",
+            "username": "user",
+            "profile": {"first_name": "user_test"}
+        }
+
+        response_intent_manager = {
+            "intent": {
+                "intent": {
+                    "name": "get_smells",
+                    "confidence": 0.8
+                }
+            },
+            "entities": {"url": "https://github.com/tensorflow/ranking"}
+        }
+
+        response = {
+            "files": [],
+            "result": [
+                "test",
+                "BCE"
+            ]
+        }
+
+        # Mock the Response objects with a mock dict
+        mock_response_intent_manager = Mock(spec=requests.Response)
+        mock_response_intent_manager.json.return_value = response_intent_manager
+        mock_response_tools = Mock(spec=requests.Response)
+        mock_response_tools.json.return_value = response
+
+        # Mock requests.get method
+        mocker.patch("intent_manager.requests.get",
+                     side_effect=[mock_response_intent_manager, mock_response_tools])
+
+        # Mock os.environ.get method
+        mocker.patch('tools.os.environ.get', side_effect=[
+            "CADOCSNLU_URL_PREDICT", "0.77", "0.55", "0.77"])
+
+        response, results, entities, intent = cadocs_instance.new_message(
+            exec_data, "channel", user)
+
+        # Assertions
+        # The produced message is not asserted in this class because it was already tested in unit test
+        assert results == ["BCE"]
+        assert entities == ["https://github.com/tensorflow/ranking", "1"]
+        assert intent == CadocsIntents.GetSmells
+
+    def test_new_message_get_smells_valid_date(self, cadocs_instance, mocker):
+        exec_data = {
+            "text": "can you get community smells for this repo https://github.com/tensorflow/ranking from 10/10/2020",
+            "approved": True,
+            "executed": False
+        }
+        user = {
+            "id": "1",
+            "username": "user",
+            "profile": {"first_name": "user_test"}
+        }
+
+        response_intent_manager = {
+            "intent": {
+                "intent": {
+                    "name": "get_smells_date",
+                    "confidence": 0.8
+                }
+            },
+            "entities": {"url": "https://github.com/tensorflow/ranking",
+                         "date": "10/10/2020"}
+        }
+
+        response = {
+            "files": [],
+            "result": [
+                "test",
+                "BCE"
+            ]
+        }
+
+        # Mock the Response objects with a mock dict
+        mock_response_intent_manager = Mock(spec=requests.Response)
+        mock_response_intent_manager.json.return_value = response_intent_manager
+        mock_response_tools = Mock(spec=requests.Response)
+        mock_response_tools.json.return_value = response
+
+        # Mock requests.get method
+        mocker.patch("intent_manager.requests.get",
+                     side_effect=[mock_response_intent_manager, mock_response_tools])
+
+        # Mock os.environ.get method
+        mocker.patch('tools.os.environ.get', side_effect=[
+            "CADOCSNLU_URL_PREDICT", "0.77", "0.55", "0.77"])
+
+        response, results, entities, intent = cadocs_instance.new_message(
+            exec_data, "channel", user)
+
+        # Assertions
+        assert results == ["BCE"]
+        assert entities == [
+            "https://github.com/tensorflow/ranking", "10/10/2020", "1"]
+        assert intent == CadocsIntents.GetSmellsDate
+
+    def test_new_message_get_smells_valid_link_low_confidence(self, cadocs_instance, mocker):
+        exec_data = {
+            "text": "can you get community smells for this repo https://github.com/tensorflow/ranking",
+            "approved": False,
+            "executed": False
+        }
+        user = {
+            "id": "1",
+            "username": "user",
+            "profile": {"first_name": "user_test"}
+        }
+
+        response_intent_manager = {
+            "intent": {
+                "intent": {
+                    "name": "get_smells",
+                    "confidence": 0.2
+                }
+            },
+            "entities": {"url": "https://github.com/tensorflow/ranking"}
+        }
+
+        # Mock the Response objects with a mock dict
+        mock_response_intent_manager = Mock(spec=requests.Response)
+        mock_response_intent_manager.json.return_value = response_intent_manager
+
+        # Mock requests.get method
+        mocker.patch("intent_manager.requests.get",
+                     return_value=mock_response_intent_manager)
+
+        # Mock os.environ.get method
+        mocker.patch('os.environ.get', side_effect=[
+            "CADOCSNLU_URL_PREDICT", "0.77", "0.55", "0.77", "0.5"])
+
+        response, results, entities, intent = cadocs_instance.new_message(
+            exec_data, "channel", user)
+
+        # Assertions
+        assert results == None
+        assert entities == None
+        assert intent == None
+
+    def test_new_message_get_smells_w_ask_confirm(self, cadocs_instance, mocker):
+        exec_data = {
+            "text": "can you get community smells for this repo https://github.com/tensorflow/ranking",
+            "approved": False,
+            "executed": False
+        }
+        user = {
+            "id": 1,
+            "username": "user",
+            "profile": {"first_name": "user_test"}
+        }
+
+        channel_test = 1
+        response_intent_manager = {
+            "intent": {
+                "intent": {
+                    "name": "get_smells",
+                    "confidence": 0.6
+                }
+            },
+            "entities": {"url": "https://github.com/tensorflow/ranking"}
+        }
+
+        mocker.patch('tools.os.environ.get', side_effect=[
+            "CADOCSNLU_URL_PREDICT", "0.77", "0.55"])
+        # Mock of the Response object
+        mock_response = mocker.Mock(spec=requests.Response)
+        mock_response.json.return_value = response_intent_manager
+        mocker.patch("intent_manager.requests.get", return_value=mock_response)
+
+        response = {
+            "files": [],
+            "result": [
+                "test",
+                "response"
+            ]
+        }
+
+        expected_response = {
+            "channel": 1,
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "Do you want me to predict community smells?"
+                    }
+                },
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Yes",
+                                "emoji": True
+                            },
+                            "value": "yes",
+                            "action_id": "action-yes"
+                        },
+                        {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "No",
+                                "emoji": True
+                            },
+                            "value": "no",
+                            "action_id": "action-no"
+                        }
+                    ]
+                }
+            ]
+        }
+
+        response, results, entities, intent = cadocs_instance.new_message(
+            exec_data, channel_test, user)
+
+        # Assertions
+        assert response == expected_response
+        assert results == None
+        assert entities == None
+        assert intent == None

--- a/tests/intent_test/IntentResolver_integration_test.py
+++ b/tests/intent_test/IntentResolver_integration_test.py
@@ -1,0 +1,238 @@
+from src import intent_resolver, utils, tools, tool_selector
+from intent_resolver import IntentResolver
+from utils import CadocsIntents
+from tool_selector import ToolSelector
+from tools import CsDetectorTool
+from tests.service_test.cadocs_messages_unit_test import TestCadocsMessagesUT
+import pytest
+import requests
+import json
+
+
+class TestIntentResolverIT:
+
+    # The tests focus on the ability to resolve an intent and build the message
+
+    # Creation of the instance of TestCadocsMessagesUT to use its methods to create text blocks
+    @pytest.fixture
+    def cadocs_messages_instance(self):
+        test_cadocs_messages_ut_instance = TestCadocsMessagesUT()
+        return test_cadocs_messages_ut_instance
+
+    # Creation of the instance of IntentResolver class
+    @pytest.fixture
+    def intent_resolver_instance(self):
+        intent_resolver = IntentResolver()
+        yield intent_resolver
+
+    # Parametrization of tests with input for get smell and get smell date
+    @pytest.mark.parametrize("intent, entities", [
+        (CadocsIntents.GetSmells, ["https://github.com/tensorflow/ranking"]),
+        (CadocsIntents.GetSmellsDate, [
+         "https://github.com/tensorflow/ranking", "12/12/2022"]),
+    ])
+    def test_resolve_intent_get_smells_and_date(self, intent_resolver_instance, mocker, intent, entities):
+        # Mock the csDetector response
+        response = {
+            "files": [],
+            "result": [
+                "test",
+                "response"
+            ]
+        }
+
+        # Mock of the dotenv module
+        mocker.patch('tools.os.environ.get',
+                     return_value="CSDETECTOR_URL_GETSMELLS")
+
+        # Mock of the Response object
+        mock_response = mocker.Mock(spec=requests.Response)
+        mock_response.json.return_value = response
+        mocker.patch("tools.requests.get", return_value=mock_response)
+
+        result = intent_resolver_instance.resolve_intent(intent, entities)
+
+        assert result == ["response"]
+
+    # Parametrization of tests with input for info and report
+    @pytest.mark.parametrize("intent, entities", [
+        (CadocsIntents.Info, []),
+        (CadocsIntents.Report, []),
+    ])
+    def test_resolve_intent_info_and_report(self, intent_resolver_instance, mocker, intent, entities):
+        # Mock the csDetector response
+        response = {
+            "files": [],
+            "result": [
+                "test",
+                "response"
+            ]
+        }
+
+        # Mock of the dotenv module
+        mocker.patch('tools.os.environ.get',
+                     return_value="CSDETECTOR_URL_GETSMELLS")
+
+        # Mock of the Response object
+        mock_response = mocker.Mock(spec=requests.Response)
+        mock_response.json.return_value = response
+        mocker.patch("tools.requests.get", return_value=mock_response)
+
+        result = intent_resolver_instance.resolve_intent(intent, entities)
+
+        assert result == []
+
+    def test_build_message_get_smells(self, intent_resolver_instance, cadocs_messages_instance):
+        user = {
+            "profile": {
+                "first_name": "test"
+            }
+        }
+        intent_test = CadocsIntents.GetSmells
+        smells_test = ["OSE", "BCE"]
+        channel_test = 1
+        entities_test = ["repository", "exec_type"]
+
+        blocks = cadocs_messages_instance.initial_block(
+            user.get("profile").get("first_name"))
+
+        text_test = "These are the community smells we were able to detect in the repository " + \
+            entities_test[0]+":"
+
+        cadocs_messages_instance.append_second_block(
+            blocks, text_test)
+
+        cadocs_messages_instance.append_found_smells_block(smells_test, blocks)
+
+        cadocs_messages_instance.append_final_block(blocks)
+
+        result = intent_resolver_instance.build_message(
+            smells_test, user, channel_test, intent_test, entities_test)
+
+        expected_response = {"channel": channel_test,
+                             "blocks": blocks}
+
+        # Assertion
+        assert result == expected_response
+
+    def test_build_message_report(self, intent_resolver_instance, cadocs_messages_instance):
+        user = {
+            "profile": {
+                "first_name": "test"
+            }
+        }
+
+        channel_test = 1
+        exec_type_test = "exec_type_test"
+        results_test = ["OSE", "BCE"]
+        entities_test = ["repository", "date", "exec_type_test"]
+        intent_test = CadocsIntents.Report
+
+        blocks = cadocs_messages_instance.initial_block(
+            user.get("profile").get("first_name"))
+
+        blocks.append({
+            "type": "section",
+            "text": {
+                    "type": "plain_text",
+                    "text": "This is a summary of your last execution",
+                    "emoji": True
+            }
+        })
+        blocks.append({
+            "type": "section",
+            "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "*Type:*\n"+exec_type_test
+                    },
+                {
+                        "type": "mrkdwn",
+                        "text": "*Repository:*\n"+entities_test[0]
+                }
+            ]
+        })
+        smells = ""
+        for r in results_test:
+            smells = smells + r + "\n"
+        blocks.append({
+            "type": "section",
+            "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "*Date:*\n"+entities_test[1]
+                    },
+                {
+                        "type": "mrkdwn",
+                        "text": "*Results:*\n"+smells
+                }
+            ]
+        })
+
+        result = intent_resolver_instance.build_message(
+            results_test, user, channel_test, intent_test, entities_test)
+
+        expected_response = {"channel": channel_test,
+                             "blocks": blocks}
+
+        # Assertion
+        assert result == expected_response
+
+    def test_build_message_info(self, intent_resolver_instance, cadocs_messages_instance):
+        user = {
+            "profile": {
+                "first_name": "test"
+            }
+        }
+
+        channel_test = 1
+        exec_type_test = "exec_type_test"
+        results_test = ["OSE", "BCE"]
+        entities_test = ["repository", "date", "exec_type_test"]
+        intent_test = CadocsIntents.Info
+
+        blocks = cadocs_messages_instance.initial_block(
+            user.get("profile").get("first_name"))
+
+        blocks.append({
+            "type": "section",
+            "text": {
+                    "type": "mrkdwn",
+                    "text": "These are the *community smells* I can detect in your development communities:"
+            }
+        })
+        blocks.append({
+            "type": "divider"
+        })
+
+        with open('src/community_smells.json') as fp:
+            data = json.load(fp)
+            for i in data:
+                blocks.append(
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*"+i.get('name')+"*  -  "+i.get('acronym')+"  -  "+i.get('emoji')+"\n"+i.get('description')
+                        }
+                    }
+                )
+        blocks.append({
+            "type": "divider"
+        })
+        blocks.append({
+            "type": "section",
+            "text": {
+                    "type": "mrkdwn",
+                    "text": "If you want to remain up-to-date, please follow us on our social networks:\n -Instagram: <https://www.instagram.com/sesa_lab/|sesa_lab> \t -Twitter: <https://twitter.com/sesa_lab|@SeSa_Lab> \t -Website: <https://sesalabunisa.github.io/en/index.html|sesalabunisa.github.io> \n Also, feel free to get in touch with us to have a discussion about the subject by sending us an email at slambiase@unisa.it!"
+            }
+        })
+
+        result = intent_resolver_instance.build_message(
+            results_test, user, channel_test, intent_test, entities_test)
+
+        expected_response = {"channel": channel_test,
+                             "blocks": blocks}
+
+        # Assertion
+        assert result == expected_response

--- a/tests/intent_test/ToolSelector_integration_test.py
+++ b/tests/intent_test/ToolSelector_integration_test.py
@@ -1,0 +1,49 @@
+import pytest
+import requests
+from src import tool_selector, tools
+
+
+class TestToolSelectorIT:
+
+    # The tests focus on the ability to set the correct strategy
+    # and being able change it as well as to run the strategy like in unit test
+
+    # Here is tested the setter of the class
+    def test_setter(self):
+        tool_selector_test = tool_selector.ToolSelector(
+            tools.CsDetectorTool())
+        # another instance of CsDetectorTool is created and assigned to the tool_selector using its setter
+        new_strategy_implementation = tools.CsDetectorTool
+        tool_selector_test.strategy = new_strategy_implementation
+        # Assertion
+        assert tool_selector_test.strategy == new_strategy_implementation
+
+    # Here is tested the ability of the class to return the same output of the set strategy implementation
+    def test_run(self, mocker):
+        tool_selector_test = tool_selector.ToolSelector(
+            tools.CsDetectorTool())
+
+        data_test = ["data1", "data2"]
+
+        # Mock the csDetector response
+        response = {
+            "files": [],
+            "result": [
+                "test",
+                "response"
+            ]
+        }
+
+        # Mock of the dotenv module
+        mocker.patch('tools.os.environ.get',
+                     return_value="CSDETECTOR_URL_GETSMELLS")
+
+        # Mock of the Response object
+        mock_response = mocker.Mock(spec=requests.Response)
+        mock_response.json.return_value = response
+        mocker.patch("tools.requests.get", return_value=mock_response)
+
+        response = tool_selector_test.run(data_test)
+
+        # Assertion
+        assert ["response"] == response


### PR DESCRIPTION
* add ITs for ToolSelector class with its under modules
* add ITs for IntentResolver class with its under modules
* add ITs for Cadocs class with its under modules
* add ITs for slack_api_connection module with its under modules

Closes #17

Co-authored-by: Davide La Gamba <d.lagamba@studenti.unisa.it>
Co-authored-by: Kevin Pacifico <k.pacifico@studenti.unisa.it>