### PR TITLE
refactor(chatbot): remove retraining functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ In case you faced some error installing the Anaconda environment, please proceed
     SLACK_TOKEN = The Bot User OAuth Token that you will find in the OAuth & Permissions section within the app you created in the Step 2
     SLACK_EVENT_TOKEN = The Signing Secret that you will find in the Basic Information section within the app you created in the Step 2
     GIT_PAT = GitHub Personal Access Token that you can generate within the Developer Settings in your GitHub account settings (make sure you give at least the "Repo" permissions)
-    ACTIVE_LEARNING_THRESHOLD = A numeric value that indicates the threshold of confidence needed by the agent to ask if its prediction was correct (We suggest 0.77) 
     MINIMUM_CONFIDENCE = A numeric value that indicates the minumum confidence needed by the agent to execute an intent (We suggest 0.55)
     CADOCSNLU_URL_PREDICT = https://sesacadocs.eu.ngrok.io/cadocsNLU/predict
     CADOCSNLU_URL_UPDATE = https://sesacadocs.eu.ngrok.io/cadocsNLU/update
@@ -197,7 +196,6 @@ This section will explain how to put together the three modules in order to make
     SLACK_TOKEN = The Bot User OAuth Token that you will find in the OAuth & Permissions section within the app you created in the Step 2
     SLACK_EVENT_TOKEN = The Signing Secret that you will find in the Basic Information section within the app you created in the Step 2
     GIT_PAT = GitHub Personal Access Token that you can generate within the Developer Settings in your GitHub settings
-    ACTIVE_LEARNING_THRESHOLD = A numeric value that indicates the threshold of confidence needed by the agent to ask if its prediction was correct (We suggest 0.77) 
     MINIMUM_CONFIDENCE = A numeric value that indicates the minumum confidence needed by the agent to execute an intent (We suggest 0.55)
     CADOCSNLU_URL_PREDICT = YOUR_NGROK_URL/cadocsNLU/predict
     CADOCSNLU_URL_UPDATE = YOUR_NGROK_URL/cadocsNLU/update

--- a/tests/api_test/slack_api_connection_integration_test.py
+++ b/tests/api_test/slack_api_connection_integration_test.py
@@ -44,7 +44,7 @@ class TestSlackAPIConnectionIT:
                             "chat_postMessage", return_value=data_test.get("message"))
 
         mocker.patch('src.api.slack_api_connection.os.environ.get', side_effect=[
-            "CADOCSNLU_URL_PREDICT", "0.77", "0.55", "0.77", "CSDETECTOR_URL_GETSMELLS"])
+            "CADOCSNLU_URL_PREDICT", "0.55", "CSDETECTOR_URL_GETSMELLS"])
 
         response_intent_manager = {
             "intent": {
@@ -76,7 +76,7 @@ class TestSlackAPIConnectionIT:
 
         # Mock os.environ.get method
         mocker.patch('intent_handling.tools.os.environ.get', side_effect=[
-            "CADOCSNLU_URL_PREDICT", "0.77", "0.55", "0.77"])
+            "CADOCSNLU_URL_PREDICT", "0.55"])
 
         expected_response = {"message": "true"}
         response = slack_api_connection.handle_request(payload)

--- a/tests/api_test/slack_api_connection_unit_test.py
+++ b/tests/api_test/slack_api_connection_unit_test.py
@@ -198,30 +198,3 @@ class TestSlackAPIConnectionUT:
         # Assertion for verify the text of response
         assert response.get_data(
             as_text=True) == "Error: No message to provide to the model. Please insert a valid message."
-
-    def test_update_dataset(self, mocker, client):
-        # Mock of the Response object
-        mock_response = mocker.Mock(spec=requests.Response)
-        mocker.patch("src.api.slack_api_connection.requests.get",
-                     return_value=mock_response)
-
-        client.get(
-            "/cadocsNLU/update?message=hello i'm tester&intent=test_intent")
-
-        expected_url = "http://localhost:5000/update_dataset?message=hello i'm tester&intent=test_intent"
-
-        # Assertion for verify the url called
-        requests.get.assert_called_once_with(expected_url)
-
-    @pytest.mark.parametrize("args", ["?message=hello i'm tester", "?intent=test_intent", ""])
-    def test_update_dataset_no_message_no_intent(self, mocker, client, args):
-        # Mock of the Response object
-        mock_response = mocker.Mock(spec=requests.Response)
-        mocker.patch("src.api.slack_api_connection.requests.get",
-                     return_value=mock_response)
-
-        response = client.get(f"/cadocsNLU/update{args}")
-
-        # Assertion for verify the text of response
-        assert response.get_data(
-            as_text=True) == "Error: The past message or intent is incorrect. Please provide the right parameters."

--- a/tests/chatbot_test/Cadocs_slack_integration_test.py
+++ b/tests/chatbot_test/Cadocs_slack_integration_test.py
@@ -20,7 +20,6 @@ class TestCadocsSlackIT:
     def test_new_message_get_smells_valid_link(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https://github.com/tensorflow/ranking",
-            "approved": True,
             "executed": False
         }
         user = {
@@ -58,8 +57,8 @@ class TestCadocsSlackIT:
                      side_effect=[mock_response_intent_manager, mock_response_tools])
 
         # Mock os.environ.get method
-        mocker.patch('src.intent_handling.tools.os.environ.get', side_effect=[
-            "CADOCSNLU_URL_PREDICT", "0.77", "0.55", "0.77"])
+        mocker.patch('src.intent_handling.tools.os.environ.get', return_value="CADOCSNLU_URL_PREDICT")
+        mocker.patch('src.chatbot.cadocs_slack.os.environ.get', return_value="0.55")
 
         response, results, entities, intent = cadocs_instance.new_message(
             exec_data, "channel", user)
@@ -73,7 +72,6 @@ class TestCadocsSlackIT:
     def test_new_message_get_smells_valid_date(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https://github.com/tensorflow/ranking from 10/10/2020",
-            "approved": True,
             "executed": False
         }
         user = {
@@ -111,9 +109,9 @@ class TestCadocsSlackIT:
         mocker.patch("src.chatbot.intent_manager.requests.get",
                      side_effect=[mock_response_intent_manager, mock_response_tools])
 
-        # Mock os.environ.get method
-        mocker.patch('src.intent_handling.tools.os.environ.get', side_effect=[
-            "CADOCSNLU_URL_PREDICT", "0.77", "0.55", "0.77"])
+       # Mock os.environ.get method
+        mocker.patch('src.intent_handling.tools.os.environ.get', return_value="CADOCSNLU_URL_PREDICT")
+        mocker.patch('src.chatbot.cadocs_slack.os.environ.get', return_value="0.55")
 
         response, results, entities, intent = cadocs_instance.new_message(
             exec_data, "channel", user)
@@ -127,7 +125,6 @@ class TestCadocsSlackIT:
     def test_new_message_get_smells_valid_link_low_confidence(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https://github.com/tensorflow/ranking",
-            "approved": False,
             "executed": False
         }
         user = {
@@ -156,97 +153,12 @@ class TestCadocsSlackIT:
 
         # Mock os.environ.get method
         mocker.patch('os.environ.get', side_effect=[
-            "CADOCSNLU_URL_PREDICT", "0.77", "0.55", "0.77", "0.5"])
+            "CADOCSNLU_URL_PREDICT", "0.55", "0.5"])
 
         response, results, entities, intent = cadocs_instance.new_message(
             exec_data, "channel", user)
 
         # Assertions
-        assert results == None
-        assert entities == None
-        assert intent == None
-
-    def test_new_message_get_smells_w_ask_confirm(self, cadocs_instance, mocker):
-        exec_data = {
-            "text": "can you get community smells for this repo https://github.com/tensorflow/ranking",
-            "approved": False,
-            "executed": False
-        }
-        user = {
-            "id": 1,
-            "username": "user",
-            "profile": {"first_name": "user_test"}
-        }
-
-        channel_test = 1
-        response_intent_manager = {
-            "intent": {
-                "intent": {
-                    "name": "get_smells",
-                    "confidence": 0.6
-                }
-            },
-            "entities": {"url": "https://github.com/tensorflow/ranking"}
-        }
-
-        mocker.patch('src.intent_handling.tools.os.environ.get', side_effect=[
-            "CADOCSNLU_URL_PREDICT", "0.77", "0.55"])
-        # Mock of the Response object
-        mock_response = mocker.Mock(spec=requests.Response)
-        mock_response.json.return_value = response_intent_manager
-        mocker.patch("src.chatbot.intent_manager.requests.get", return_value=mock_response)
-
-        response = {
-            "files": [],
-            "result": [
-                "test",
-                "response"
-            ]
-        }
-
-        expected_response = {
-            "channel": 1,
-            "blocks": [
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "Do you want me to predict community smells?"
-                    }
-                },
-                {
-                    "type": "actions",
-                    "elements": [
-                        {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "Yes",
-                                "emoji": True
-                            },
-                            "value": "yes",
-                            "action_id": "action-yes"
-                        },
-                        {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "No",
-                                "emoji": True
-                            },
-                            "value": "no",
-                            "action_id": "action-no"
-                        }
-                    ]
-                }
-            ]
-        }
-
-        response, results, entities, intent = cadocs_instance.new_message(
-            exec_data, channel_test, user)
-
-        # Assertions
-        assert response == expected_response
         assert results == None
         assert entities == None
         assert intent == None

--- a/tests/chatbot_test/Cadocs_slack_unit_test.py
+++ b/tests/chatbot_test/Cadocs_slack_unit_test.py
@@ -17,7 +17,6 @@ class TestCadocsSlackUT:
     def test_new_message_get_smells_valid_link_high_confidence(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https-://github.com/tensorflow/ranking",
-            "approved": True,
             "executed": False
         }
         user = {
@@ -55,51 +54,9 @@ class TestCadocsSlackUT:
         assert entities == ["https://github.com/tensorflow/ranking", 1]
         assert intent == CadocsIntents.GetSmells
 
-    def test_new_message_get_smells_valid_link_medium_confidence(self, cadocs_instance, mocker):
-        exec_data = {
-            "text": "can you get community smells for this repo https://github.com/tensorflow/ranking",
-            "approved": False,
-            "executed": False
-        }
-        user = {
-            "id": 1,
-            "username": "user",
-            "profile": {"first_name": "user_test"}
-        }
-
-        mocked_intent = CadocsIntents.GetSmells
-        mocked_entities = ["https://github.com/tensorflow/ranking"]
-        mocked_confidence = 0.6
-
-        # Mock the IntentManager object
-        mocker.patch.object(IntentManager, 'detect_intent', return_value=(
-            mocked_intent, mocked_entities, mocked_confidence))
-
-        # Mock the valid_link method
-        mocker.patch('src.chatbot.cadocs_slack.valid_link', return_value=True)
-
-        # Mock the ask_confirm method
-        mocked_result = "Confirm message"
-        mocker.patch.object(CadocsSlack, 'ask_confirm',
-                            return_value=(mocked_result))
-
-        # Mock the build_message method
-        mocker.patch('src.chatbot.cadocs_slack.build_message',
-                            return_value="get smells")
-
-        response, results, entities, intent = cadocs_instance.new_message(
-            exec_data, "channel", user)
-
-        # Assertions
-        assert response == mocked_result
-        assert results == None
-        assert entities == None
-        assert intent == None
-
     def test_new_message_get_smells_valid_link_low_confidence(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https://github.com/tensorflow/ranking",
-            "approved": False,
             "executed": False
         }
         user = {
@@ -136,7 +93,6 @@ class TestCadocsSlackUT:
     def test_new_message_get_smells_not_valid_link(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https:github.comtensorflowranking",
-            "approved": True,
             "executed": False
         }
 
@@ -170,7 +126,6 @@ class TestCadocsSlackUT:
     def test_new_message_get_smells_date_valid_link_valid_date_high_confidence(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https://github.com/tensorflow/ranking from 12/12/2022",
-            "approved": True,
             "executed": False
         }
         user = {
@@ -213,55 +168,9 @@ class TestCadocsSlackUT:
             "https://github.com/tensorflow/ranking", "12/12/2022", 1]
         assert intent == CadocsIntents.GetSmellsDate
 
-    def test_new_message_get_smells_date_valid_link_valid_date_medium_confidence(self, cadocs_instance, mocker):
-        exec_data = {
-            "text": "can you get community smells for this repo https://github.com/tensorflow/ranking from 12/12/2022",
-            "approved": False,
-            "executed": False
-        }
-        user = {
-            "id": 1,
-            "username": "user",
-            "profile": {"first_name": "user_test"}
-        }
-
-        mocked_intent = CadocsIntents.GetSmellsDate
-        mocked_entities = [
-            "https://github.com/tensorflow/ranking", "12/12/2022"]
-        mocked_confidence = 0.6
-
-        # Mock the IntentManager object
-        mocker.patch.object(IntentManager, 'detect_intent', return_value=(
-            mocked_intent, mocked_entities, mocked_confidence))
-
-        # Mock the valid_link method
-        mocker.patch('src.chatbot.cadocs_slack.valid_link', return_value=True)
-
-        # Mock the valid_date method
-        mocker.patch('src.chatbot.cadocs_slack.valid_date', return_value=True)
-
-        # Mock the ask_confirm method
-        mocked_result = "Confirm message"
-        mocker.patch.object(CadocsSlack, 'ask_confirm',
-                            return_value=(mocked_result))
-
-        # Mock the build_message method
-        mocker.patch('src.chatbot.cadocs_slack.build_message',
-                            return_value="get smells")
-
-        response, results, entities, intent = cadocs_instance.new_message(
-            exec_data, "channel", user)
-
-        # Assertions
-        assert response == mocked_result
-        assert results == None
-        assert entities == None
-        assert intent == None
-
     def test_new_message_get_smells_date_valid_link_valid_date_low_confidence(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https://github.com/tensorflow/ranking from 12/12/2022",
-            "approved": False,
             "executed": False
         }
         user = {
@@ -302,7 +211,6 @@ class TestCadocsSlackUT:
     def test_new_message_get_smells_date_not_valid_link(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https:github.comtensorflowranking from 12/12/2022",
-            "approved": True,
             "executed": False
         }
 
@@ -340,7 +248,6 @@ class TestCadocsSlackUT:
     def test_new_message_get_smells_date_not_valid_date(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https:github.comtensorflowranking from 1212/2022",
-            "approved": True,
             "executed": False
         }
 
@@ -378,7 +285,6 @@ class TestCadocsSlackUT:
     def test_new_message_get_smells_date_not_valid_link_not_valid_date(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you get community smells for this repo https:github.comtensorflowranking from 12/12/2022",
-            "approved": True,
             "executed": False
         }
 
@@ -416,7 +322,6 @@ class TestCadocsSlackUT:
     def test_new_message_report(self, cadocs_instance, mocker):
         exec_data = {
             "text": "can you give me your last report",
-            "approved": True,
             "executed": False
         }
 
@@ -460,59 +365,6 @@ class TestCadocsSlackUT:
         assert entities == [
             "https://github.com/tensorflow/ranking", "12/12/2022", "get_smells"]
         assert intent == CadocsIntents.Report
-
-    @pytest.mark.parametrize("intent, text", [
-        (CadocsIntents.GetSmells, "Do you want me to predict community smells?"),
-        (CadocsIntents.GetSmellsDate,
-         "Do you want me to predict community smells starting from a specific date?"),
-        (CadocsIntents.Report, "Do you want me to show a report of your last execution?"),
-        (CadocsIntents.Info, "Do you want to know more about community smells?"),
-    ])
-    def test_ask_confirm_get_smell(self, cadocs_instance, intent, text):
-        user = "user"
-        channel = "channel"
-
-        msg = {
-            "channel": channel,
-            "blocks": [
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": text
-                    }
-                },
-                {
-                    "type": "actions",
-                    "elements": [
-                        {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "Yes",
-                                "emoji": True
-                            },
-                            "value": "yes",
-                            "action_id": "action-yes"
-                        },
-                        {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "No",
-                                "emoji": True
-                            },
-                            "value": "no",
-                            "action_id": "action-no"
-                        }
-                    ]
-                }
-            ]
-        }
-
-        response = cadocs_instance.ask_confirm(intent, channel, user)
-
-        assert response == msg
 
     def test_error_message_url(self, cadocs_instance):
         error_type = "url"


### PR DESCRIPTION
* remove ask_confirm method from CadocsSlack
* remove handle_action, action_received and update_dataset from slack_api_connection component
* update readme.md
* remove tests of removed features and update tests

Closes #38

Co-authored-by: Davide La Gamba <d.lagamba@studenti.unisa.it>